### PR TITLE
Fixed initialization of parent in ofxGuiGroupExtended

### DIFF
--- a/src/ofxGuiGroupExtended.cpp
+++ b/src/ofxGuiGroupExtended.cpp
@@ -7,6 +7,7 @@ ofxGuiGroupExtended::ofxGuiGroupExtended(){
     _bVertical = true;
     _bUseHeader = true;
     _bAllowMultiple = true;
+	parent = NULL;
 }
 
 ofxGuiGroupExtended::ofxGuiGroupExtended(const ofParameterGroup & parameters, string filename, float x, float y)
@@ -14,6 +15,7 @@ ofxGuiGroupExtended::ofxGuiGroupExtended(const ofParameterGroup & parameters, st
     _bVertical = true;
     _bUseHeader = true;
     _bAllowMultiple = true;
+	parent = NULL;
 }
 
 ofxGuiGroupExtended * ofxGuiGroupExtended::setup(string collectionName, string filename, float x, float y){


### PR DESCRIPTION
Otherwise it crashes at least in VS2012. 
