### PR TITLE
refactored to adapt to ofxGui changes

### DIFF
--- a/exampleControls/src/ofApp.cpp
+++ b/exampleControls/src/ofApp.cpp
@@ -10,76 +10,80 @@ void ofApp::setup(){
     panel1.setup("extended gui");
     panel1.setBorderColor(ofColor::black);
 
-    panel1.add((new ofxLabelExtended())->setup("LabelName", "extended Label")->setShowLabelName(false));
+    ofxLabelExtended::Config labelConfig;
+    labelConfig.showName = false;
+    panel1.add<ofxLabelExtended>(ofParameter<std::string>("LabelName", "extended Label"), labelConfig);
 
-    panel1.add(fps.setup(0,120));
+    panel1.add<ofxFpsPlotter>();
 
     /*
      * minimal button and toggle
      */
-    panel1.add(new ofxMinimalToggle(toggle_param.set("show header", true), 0, 30));
+    ofxMinimalToggle::Config config;
+    config.shape.height = 30;
+    panel1.add<ofxMinimalToggle>(toggle_param.set("show header", true),config);
     toggle_param.addListener(this, &ofApp::toggleGroupHeader);
-    panel1.add(new ofxMinimalButton("button", 0, 30));
+    panel1.add<ofxMinimalButton>(config);
 
     /*
      * rotary slider
      */
     rotary.setup("rotary");
     rotary.setBorderColor(ofColor::blanchedAlmond - ofColor(50));
-    rotary.add(new ofxFloatRotarySlider(slider_param.set("slider", 0.5, 0, 1), 66,66));
+    ofxRotarySlider<float>::Config rotaryConfig;
+    rotaryConfig.shape.width = rotaryConfig.shape.height = 66;
+    rotary.add<ofxFloatRotarySlider>(slider_param.set("slider", 0.5, 0, 1), rotaryConfig);
     rotary.getControl("slider")->setFillColor(ofColor::white);
     rotary.getControl("slider")->setBackgroundColor(ofColor::blanchedAlmond - ofColor(130));
 
     /*
      * matrix with only one allowed active toggle
      */
-    matrix_params.push_back(ofParameter<bool>("only",false));
-    matrix_params.push_back(ofParameter<bool>("one",false));
-    matrix_params.push_back(ofParameter<bool>("toggle",false));
-    matrix_params.push_back(ofParameter<bool>("can",false));
-    matrix_params.push_back(ofParameter<bool>("be",false));
-    matrix_params.push_back(ofParameter<bool>("active",false));
     matrix.setup("matrix",3);
-    for(unsigned int i = 0; i < matrix_params.size(); i++) {
-        matrix.add(new ofxMinimalToggle(matrix_params.at(i)));
-    }
+    matrix.add<ofxMinimalToggle>(ofParameter<bool>("only",false));
+    matrix.add<ofxMinimalToggle>(ofParameter<bool>("one",false));
+    matrix.add<ofxMinimalToggle>(ofParameter<bool>("toggle",false));
+    matrix.add<ofxMinimalToggle>(ofParameter<bool>("can",false));
+    matrix.add<ofxMinimalToggle>(ofParameter<bool>("be",false));
+    matrix.add<ofxMinimalToggle>(ofParameter<bool>("active",false));
     matrix.setBorderColor(ofColor::aquamarine);
     matrix.setElementHeight(26);
     matrix.allowMultipleActiveToggles(false);
 
-    panel1.add(&rotary);
-    panel1.add(&matrix);
+    panel1.add(rotary);
+    panel1.add(matrix);
 
     /*
      * horizontal panel with spacer
      */
     panel2.setup("horizontal", "", 260, 10);
-    panel2.setAlignHorizontal();
+    panel2.setLayout(ofxBaseGui::Horizontal);
     panel2.setBorderColor(ofColor::black);
-    panel2.add(new ofxToggle(toggle1_param.set("toggle1", false), 100, 30));
-    panel2.add(new ofxMinimalToggle(toggle2_param.set("toggle2", false), 0, 30));
-    panel2.add(new ofxGuiSpacer(30));
-    panel2.add(new ofxMinimalToggle(toggle3_param.set("toggle3", false), 0, 30));
-    panel2.add(new ofxMinimalToggle(toggle4_param.set("toggle4", false), 0, 30));
+    ofxToggle::Config toggleConfig;
+    toggleConfig.shape.width = 100;
+    toggleConfig.shape.height = 30;
+    panel2.add(toggle1_param.set("toggle1", false), toggleConfig);
+    panel2.add<ofxMinimalToggle>(toggle2_param.set("toggle2", false), toggleConfig);
+    panel2.add<ofxGuiSpacer>(ofxGuiSpacer::Config(30));
+    panel2.add<ofxMinimalToggle>(toggle3_param.set("toggle3", false), toggleConfig);
+    panel2.add<ofxMinimalToggle>(toggle4_param.set("toggle4", false), toggleConfig);
 
     /*
      * panel with canvas
      */
     panel3.setup("canvas", "", 260, 90);
     img.load("images/ente.jpg");
-    canvas.setup("some texture", &img.getTexture());
-    panel3.add(&canvas);
+    panel3.add<ofxGuiBaseDraws>(ofxGuiBaseDraws::Config("some texture", &img.getTexture()));
 
     panel4.setup("zoomable canvas", "", 500, 90);
-    zcanvas.setup("same texture", &img.getTexture());
-    panel4.add(&zcanvas);
+    panel4.add<ofxGuiBaseDraws>(ofxGuiBaseDraws::Config("same texture", &img.getTexture()));
 
     panel5.setup("vertical sliders", "", 260, 280);
-    panel5.setAlignHorizontal();
-    panel5.add(new ofxFloatVerticalSlider(slider1_param.set("slider1", 1./7., 0, 1)));
-    panel5.add(new ofxFloatVerticalSlider(slider2_param.set("slider2", 5./7., 0, 1)));
-    panel5.add(new ofxFloatVerticalSlider(slider3_param.set("slider3", 4./7., 0, 1)));
-    panel5.add(new ofxFloatVerticalSlider(slider4_param.set("slider4", 6./7., 0, 1)));
+    panel5.setLayout(ofxBaseGui::Horizontal);
+    panel5.add<ofxFloatVerticalSlider>(slider1_param.set("slider1", 1./7., 0, 1));
+    panel5.add<ofxFloatVerticalSlider>(slider2_param.set("slider2", 5./7., 0, 1));
+    panel5.add<ofxFloatVerticalSlider>(slider3_param.set("slider3", 4./7., 0, 1));
+    panel5.add<ofxFloatVerticalSlider>(slider4_param.set("slider4", 6./7., 0, 1));
     panel5.getControl("slider1")->setSize(40, 130);
     panel5.getControl("slider2")->setSize(50, 130);
     panel5.getControl("slider3")->setSize(60, 130);
@@ -93,7 +97,7 @@ void ofApp::exit() {
 
 //--------------------------------------------------------------
 void ofApp::update() {
-    fps.update();
+    //fps.update();
 }
 
 //--------------------------------------------------------------
@@ -107,12 +111,12 @@ void ofApp::draw(){
             ofSetColor(ofColor::azure);
         }
         else {
-            if(matrix_params.at(0).get()) {
+            /*if(matrix_params.at(0).get()) {
                 ofSetColor(ofColor::burlyWood);
             }
             else {
                 ofSetColor(ofColor::fromHex(0x2da1e3));
-            }
+            }*/
         }
     }
 

--- a/exampleControls/src/ofApp.h
+++ b/exampleControls/src/ofApp.h
@@ -29,10 +29,6 @@ private:
     ofxGuiMatrix matrix;
 
     ofImage img;
-    ofxGuiBaseDraws canvas;
-    ofxGuiZoomableBaseDraws zcanvas;
-
-    ofxFpsPlotter fps;
 
     ofParameter<bool> toggle_param;
     ofParameter<float> slider_param;

--- a/src/ofxFpsPlotter.cpp
+++ b/src/ofxFpsPlotter.cpp
@@ -1,28 +1,23 @@
 #include "ofxFpsPlotter.h"
 #include "ofAppRunner.h"
 
-ofxFpsPlotter::ofxFpsPlotter() {}
-
-ofxFpsPlotter::ofxFpsPlotter(float minValue, float maxValue, int plotSize, float width, float height){
-    setup(minValue, maxValue, plotSize, width, height);
+ofxFpsPlotter::ofxFpsPlotter(const ofxValuePlotter::Config & c)
+:ofxValuePlotter(ofParameter<float>("fps",0),c){
+    if(minVal == maxVal) {
+        if(ofGetTargetFrameRate() > 0) {
+        	minVal = 0;
+        	maxVal = ofGetTargetFrameRate();
+        }
+    }
+    setDecimalPlace(0);
+    ofAddListener(ofEvents().update,this,&ofxFpsPlotter::update);
 }
 
 ofxFpsPlotter::~ofxFpsPlotter(){
+	ofRemoveListener(ofEvents().update,this,&ofxFpsPlotter::update);
 }
 
-ofxFpsPlotter* ofxFpsPlotter::setup(float minValue, float maxValue, int plotSize, float width, float height) {
-    if(minValue == maxValue) {
-        if(ofGetTargetFrameRate() > 0) {
-            minValue = 0;
-            maxValue = ofGetTargetFrameRate();
-        }
-    }
-    ofxValuePlotter::setup("FPS", minValue, maxValue, plotSize, width, height);
-    setDecimalPlace(0);
-    return this;
-}
-
-void ofxFpsPlotter::update() {
-    ofxValuePlotter::update(ofGetFrameRate());
+void ofxFpsPlotter::update(ofEventArgs &) {
+    value = ofGetFrameRate();
 }
 

--- a/src/ofxFpsPlotter.h
+++ b/src/ofxFpsPlotter.h
@@ -4,14 +4,9 @@
 
 class ofxFpsPlotter: public ofxValuePlotter {
 public:
-    ofxFpsPlotter();
-    ofxFpsPlotter(float minValue, float maxValue, int plotSize=100, float width = defaultWidth, float height = defaultHeight);
+    ofxFpsPlotter(const ofxValuePlotter::Config & c);
     virtual ~ofxFpsPlotter();
-
-    void update();
-
-    ofxFpsPlotter * setup(float minValue=0, float maxValue=0, int plotSize=100, float width = defaultWidth, float height = defaultHeight);
-
 protected:
+    void update(ofEventArgs &);
 
 };

--- a/src/ofxGuiBaseDraws.cpp
+++ b/src/ofxGuiBaseDraws.cpp
@@ -2,34 +2,19 @@
 #include "ofGraphics.h"
 using namespace std;
 
-ofxGuiBaseDraws::ofxGuiBaseDraws() {
-    _bLoaded = false;
-}
-
-ofxGuiBaseDraws::ofxGuiBaseDraws(string canvasName, ofBaseDraws *graphics, float w, float h){
-    _bLoaded = false;
-    setup(canvasName,graphics,w,h);
-}
-
-ofxGuiBaseDraws::ofxGuiBaseDraws(ofBaseDraws* graphics, float w, float h){
-    setup("",graphics,w,h);
-}
-
 ofxGuiBaseDraws::~ofxGuiBaseDraws(){
 }
 
-ofxGuiBaseDraws* ofxGuiBaseDraws::setup(string canvasName, ofBaseDraws *graphics, float w, float h) {
-    if(graphics->getHeight() != 0 && graphics->getWidth() != 0) {
+ofxGuiBaseDraws::ofxGuiBaseDraws(const Config & config){
+	graphics = config.graphics;
+    if(graphics && graphics->getHeight() != 0 && graphics->getWidth() != 0) {
         _bLoaded = true;
-        setName(canvasName);
+        setName(config.canvasName);
         this->graphics = graphics;
-        setSize(w,h);
-    }
-    else {
+        setSize(config.shape.width,config.shape.height);
+    }  else {
         ofLogError("ofxCanvas:setup()", "graphics cannot be loaded, width = 0 or height = 0");
     }
-
-    return this;
 }
 
 void ofxGuiBaseDraws::setSize(float w, float h){

--- a/src/ofxGuiBaseDraws.h
+++ b/src/ofxGuiBaseDraws.h
@@ -4,12 +4,17 @@
 
 class ofxGuiBaseDraws: public ofxBaseGui {
 public:
-    ofxGuiBaseDraws();
-    ofxGuiBaseDraws(string canvasName, ofBaseDraws* graphics = 0, float w = 0, float h = 0);
-    ofxGuiBaseDraws(ofBaseDraws *graphics, float w = defaultWidth, float h = 0);
-    virtual ~ofxGuiBaseDraws();
+	struct Config: public ofxBaseGui::Config{
+		Config(const std::string & name, ofBaseDraws * graphics)
+		:canvasName(name)
+		,graphics(graphics){
 
-    ofxGuiBaseDraws * setup(string canvasName = "", ofBaseDraws* graphics = 0, float w = 0, float h = 0);
+		}
+		std::string canvasName;
+		ofBaseDraws* graphics=nullptr;
+	};
+    ofxGuiBaseDraws(const Config & config);
+    virtual ~ofxGuiBaseDraws();
 
     // Abstract methods we must implement, but have no need for!
     virtual bool mouseMoved(ofMouseEventArgs & args){return false;}
@@ -30,7 +35,7 @@ protected:
     ofPath bg;
     ofVboMesh textMesh;
     ofBaseDraws* graphics;
-    ofParameter<string> label;
+    ofParameter<std::string> label;
     bool _bLoaded;
 
 };

--- a/src/ofxGuiGroupExtended.cpp
+++ b/src/ofxGuiGroupExtended.cpp
@@ -413,9 +413,9 @@ float ofxGuiGroupExtended::getContentHeight() {
     if(_bUseHeader) {
        h -= header;
     }
-    /*if(parent) {
+    if(inContainer) {
         h -= spacingNextElement;
-    }*/
+    }
     return h;
 }
 
@@ -423,25 +423,25 @@ void ofxGuiGroupExtended::setContentHeight(float h) {
     if(_bUseHeader) {
         h += header;
     }
-    /*if(parent) {
+    if(inContainer) {
         h += spacingNextElement;
-    }*/
+    }
     h += spacing;
     b.height = h;
 }
 
 float ofxGuiGroupExtended::getContentWidth() {
     float w = b.width - spacing;
-    /*if(parent) {
+    if(inContainer) {
         w -= spacingNextElement;
-    }*/
+    }
     return w;
 }
 
 void ofxGuiGroupExtended::setContentWidth(float w) {
-    /*if(parent) {
+    if(inContainer) {
         w += spacingNextElement;
-    }*/
+    }
     w += spacing;
     b.width = w;
 }

--- a/src/ofxGuiGroupExtended.h
+++ b/src/ofxGuiGroupExtended.h
@@ -4,20 +4,15 @@
 
 class ofxGuiGroupExtended : public ofxGuiGroup {
 
-    friend class ofxGuiMatrix;
-    friend class ofxGuiSpacer;
-    friend class ofxGuiPage;
-    friend class ofxTabbedPages;
-
 public:
 
     ofxGuiGroupExtended();
     ofxGuiGroupExtended(const ofParameterGroup & parameters, std::string _filename="settings.xml", float x = 10, float y = 10);
     virtual ~ofxGuiGroupExtended() {}
-    virtual ofxGuiGroupExtended * setup(std::string collectionName="", std::string filename="settings.xml", float x = 10, float y = 10);
-    virtual ofxGuiGroupExtended * setup(const ofParameterGroup & parameters, std::string filename="settings.xml", float x = 10, float y = 10);
+    virtual ofxGuiGroupExtended & setup(std::string collectionName="", std::string filename="settings.xml", float x = 10, float y = 10);
+    virtual ofxGuiGroupExtended & setup(const ofParameterGroup & parameters, std::string filename="settings.xml", float x = 10, float y = 10);
 
-    void add(ofxBaseGui * element);
+    using ofxGuiGroup::add;
 
     void clear();
 
@@ -35,10 +30,8 @@ public:
     virtual void setWidthElements(float w);
     virtual void scaleWidthElements(float factor);
 
-    void setAlignHorizontal();
-    void setAlignVertical();
-
-    bool isAlignedVertical();
+    void setLayout(ofxBaseGui::Layout layout);
+    ofxBaseGui::Layout getLayout() const;
 
     void setShowHeader(bool show);
 
@@ -48,10 +41,10 @@ public:
     int getActiveToggleIndex();
 
 protected:
+    virtual void add(ofxBaseGui * element);
     virtual void sizeChangedCB();
     virtual void render();
     virtual void generateDraw();
-    bool _bVertical;
     bool _bUseHeader;
     bool _bAllowMultiple;
 

--- a/src/ofxGuiMatrix.cpp
+++ b/src/ofxGuiMatrix.cpp
@@ -6,51 +6,29 @@ ofxGuiMatrix::ofxGuiMatrix(){
 }
 
 ofxGuiMatrix::ofxGuiMatrix(string collectionName, int cols, string filename, float x, float y)
-    :ofxGuiGroupExtended(){
+:ofxGuiGroupExtended(){
     setup(collectionName, cols, filename, x, y);
 }
 
 ofxGuiMatrix::ofxGuiMatrix(const ofParameterGroup & parameters, int cols, string filename, float x, float y)
-    :ofxGuiGroupExtended(parameters, filename, x, y){
+:ofxGuiGroupExtended(parameters, filename, x, y){
     setColNum(cols);
     sizeChangedCB();
     setNeedsRedraw();
 }
 
-ofxGuiMatrix * ofxGuiMatrix::setup(string collectionName, int cols, string filename, float x, float y){
+ofxGuiMatrix & ofxGuiMatrix::setup(string collectionName, int cols, string filename, float x, float y){
     setColNum(cols);
     ofxGuiGroupExtended::setup(collectionName,filename,x,y);
     w_matrix = b.width;
-    return this;
+    return *this;
 }
 
-ofxGuiMatrix * ofxGuiMatrix::setup(const ofParameterGroup & _parameters, int cols, string filename, float x, float y){
+ofxGuiMatrix & ofxGuiMatrix::setup(const ofParameterGroup & _parameters, int cols, string filename, float x, float y){
     setColNum(cols);
     ofxGuiGroupExtended::setup(_parameters,filename,x,y);
     w_matrix = b.width;
-    return this;
-}
-
-void ofxGuiMatrix::add(ofxBaseGui *element){
-    collection.push_back( element );
-
-    sizeChangedCB();
-
-    element->unregisterMouseEvents();
-
-    ofxGuiGroupExtended * subgroup = dynamic_cast<ofxGuiGroupExtended*>(element);
-    if(subgroup!=NULL){
-        subgroup->filename = filename;
-        subgroup->parent = this;
-        subgroup->scaleWidthElements(.98);
-    }else{
-        if(parent!=NULL){
-            scaleWidthElements(0.98);
-        }
-    }
-
-    parameters.add(element->getParameter());
-    setNeedsRedraw();
+    return *this;
 }
 
 void ofxGuiMatrix::setWidthElements(float w){
@@ -149,16 +127,14 @@ void ofxGuiMatrix::minimize(){
     if(_bUseHeader) {
         b.height += header;
     }
-    if(parent) {
-        parent->sizeChangedCB();
-    }
+    ofNotifyEvent(sizeChangedE,this);
     setNeedsRedraw();
 }
 
 void ofxGuiMatrix::maximize(){
     minimized=false;
     b.height += (h_element+spacing)*getRowNum();
-    if(parent) parent->sizeChangedCB();
+    ofNotifyEvent(sizeChangedE,this);
     setNeedsRedraw();
 }
 
@@ -193,8 +169,9 @@ void ofxGuiMatrix::sizeChangedCB(){
         if(numCol > 0) {
             y_e = (int)(i / numCol);
         }
-
+        collection[i]->sizeChangedE.disable();
         collection[i]->setSize(w_element, h_element);
+        collection[i]->sizeChangedE.enable();
 
         if(i == 0) {
             collection[i]->setPosition(x, y);
@@ -208,7 +185,7 @@ void ofxGuiMatrix::sizeChangedCB(){
 
     b.height = y + (h_element+spacing)*getRowNum()+spacing - b.y;
 
-    if(parent) parent->sizeChangedCB();
+    ofNotifyEvent(sizeChangedE,this);
     setNeedsRedraw();
 }
 

--- a/src/ofxGuiMatrix.h
+++ b/src/ofxGuiMatrix.h
@@ -7,10 +7,8 @@ public:
     ofxGuiMatrix(std::string collectionName, int cols=0, std::string _filename="settings.xml", float x = 10, float y = 10);
     ofxGuiMatrix(const ofParameterGroup & parameters, int cols=0, std::string _filename="settings.xml", float x = 10, float y = 10);
     virtual ~ofxGuiMatrix() {}
-    virtual ofxGuiMatrix * setup(std::string collectionName="", int cols=0, std::string filename="settings.xml", float x = 10, float y = 10);
-    virtual ofxGuiMatrix * setup(const ofParameterGroup & parameters, int cols=0, std::string filename="settings.xml", float x = 10, float y = 10);
-
-    void add(ofxBaseGui * element);
+    virtual ofxGuiMatrix & setup(std::string collectionName="", int cols=0, std::string filename="settings.xml", float x = 10, float y = 10);
+    virtual ofxGuiMatrix & setup(const ofParameterGroup & parameters, int cols=0, std::string filename="settings.xml", float x = 10, float y = 10);
 
     void minimize();
     void maximize();

--- a/src/ofxGuiPage.cpp
+++ b/src/ofxGuiPage.cpp
@@ -5,9 +5,9 @@ using namespace std;
 ofxGuiPage::ofxGuiPage():ofxPanelExtended(){
 }
 
-ofxGuiPage * ofxGuiPage::setup(string pageName, string filename, float x, float y){
+ofxGuiPage & ofxGuiPage::setup(string pageName, string filename, float x, float y){
     ofxPanelExtended::setup(pageName,filename,x,y);
-    return this;
+    return *this;
 }
 
 void ofxGuiPage::add(ofxBaseGui * element){
@@ -73,6 +73,6 @@ void ofxGuiPage::clear(){
 }
 
 void ofxGuiPage::sizeChangedCB(){
-    if(parent) parent->sizeChangedCB();
+	ofNotifyEvent(sizeChangedE,this);
     setNeedsRedraw();
 }

--- a/src/ofxGuiPage.h
+++ b/src/ofxGuiPage.h
@@ -7,7 +7,7 @@ public:
 
     ofxGuiPage();
     virtual ~ofxGuiPage() {}
-    virtual ofxGuiPage * setup(std::string pageName="", std::string filename="settings.xml", float x = 10, float y = 10);
+    virtual ofxGuiPage & setup(std::string pageName="", std::string filename="settings.xml", float x = 10, float y = 10);
 
     void add(ofxBaseGui * element);
 

--- a/src/ofxGuiSpacer.cpp
+++ b/src/ofxGuiSpacer.cpp
@@ -3,29 +3,19 @@
 #include "ofGraphics.h"
 using namespace std;
 
-ofxGuiSpacer::ofxGuiSpacer(string name, float size, float x, float y){
-    parent = NULL;
-    setup(name, size, x, y);
-}
-
-ofxGuiSpacer::ofxGuiSpacer(float size, float x, float y){
-    parent = NULL;
-    setup("", size, x, y);
-}
-
-ofxGuiSpacer * ofxGuiSpacer::setup(float size, float x, float y){
-    return setup("", size, x, y);
-}
-
-ofxGuiSpacer * ofxGuiSpacer::setup(string name, float size, float x, float y){
-    this->setBackgroundColor(ofColor(0,0,0,0));
-    this->setName(name);
-    this->setPosition(x,y);
-    spacing_size = size;
-    return this;
+ofxGuiSpacer::ofxGuiSpacer(const Config & config)
+:ofxBaseGui(config){
+    spacing_size = config.size;
+	if(layout==ofxBaseGui::Vertical) {
+		cout << "layout vertical " << b.width << endl;
+		b.height = spacing_size;
+	} else {
+		b.width = spacing_size;
+	}
 }
 
 void ofxGuiSpacer::generateDraw(){
+	cout << "gerating " << b.width << endl;
     bg.clear();
     bg.setFillColor(thisBackgroundColor);
     bg.setFilled(true);
@@ -34,25 +24,6 @@ void ofxGuiSpacer::generateDraw(){
 
 void ofxGuiSpacer::render(){
     bg.draw();
-}
-
-void ofxGuiSpacer::sizeChangedCB(){
-
-    if(parent) {
-
-        if(ofxGuiGroupExtended* group = dynamic_cast<ofxGuiGroupExtended*>(parent)) {
-            if(group->isAlignedVertical()) {
-                b.width = group->getWidth();
-                b.height = spacing_size;
-            }
-            else {
-                b.height = group->getContentHeight();
-                b.width = spacing_size;
-            }
-            parent->sizeChangedCB();
-        }
-    }
-    setNeedsRedraw();
 }
 
 ofAbstractParameter & ofxGuiSpacer::getParameter(){

--- a/src/ofxGuiSpacer.h
+++ b/src/ofxGuiSpacer.h
@@ -4,11 +4,16 @@
 
 class ofxGuiSpacer : public ofxBaseGui {
 public:
-    ofxGuiSpacer(std::string name, float size = 10, float x = 10, float y = 10);
-    ofxGuiSpacer(float size = 10, float x = 10, float y = 10);
+	struct Config: public ofxBaseGui::Config{
+		Config(){}
+		Config(float size=10)
+		:size(size){
+
+		}
+		float size = 10;
+	};
+    ofxGuiSpacer(const Config & config);
     virtual ~ofxGuiSpacer() {}
-    virtual ofxGuiSpacer * setup(float size, float x, float y);
-    virtual ofxGuiSpacer * setup(string name, float size, float x, float y);
 
     virtual ofAbstractParameter & getParameter();
 
@@ -22,8 +27,6 @@ protected:
     virtual void render();
     virtual bool setValue(float mx, float my, bool bCheckBounds){return false;}
     virtual void generateDraw();
-
-    void sizeChangedCB();
 
     ofPath bg;
     float spacing_size;

--- a/src/ofxGuiZoomableBaseDraws.cpp
+++ b/src/ofxGuiZoomableBaseDraws.cpp
@@ -2,25 +2,14 @@
 #include "ofGraphics.h"
 using namespace std;
 
-ofxGuiZoomableBaseDraws::ofxGuiZoomableBaseDraws() {}
-
-ofxGuiZoomableBaseDraws::ofxGuiZoomableBaseDraws(string graphicsName, ofBaseDraws *graphics, float w, float h){
-    setup(graphicsName,graphics,w,h);
-}
-
-ofxGuiZoomableBaseDraws::ofxGuiZoomableBaseDraws(ofBaseDraws *graphics, float w, float h){
-    setup("",graphics,w,h);
-}
-
-ofxGuiZoomableBaseDraws::~ofxGuiZoomableBaseDraws(){
-}
-
-ofxGuiZoomableBaseDraws* ofxGuiZoomableBaseDraws::setup(string graphicsName, ofBaseDraws *graphics, float w, float h) {
-    ofxGuiBaseDraws::setup(graphicsName, graphics, w, h);
+ofxGuiZoomableBaseDraws::ofxGuiZoomableBaseDraws(const ofxGuiBaseDraws::Config & config)
+:ofxGuiBaseDraws(config){
     zoom_factor = 0;
     zoom_speed = 0.1;
     dragging_dst = false;
-    return this;
+}
+
+ofxGuiZoomableBaseDraws::~ofxGuiZoomableBaseDraws(){
 }
 
 void ofxGuiZoomableBaseDraws::setSize(float w, float h){

--- a/src/ofxGuiZoomableBaseDraws.h
+++ b/src/ofxGuiZoomableBaseDraws.h
@@ -5,13 +5,8 @@
 
 class ofxGuiZoomableBaseDraws: public ofxGuiBaseDraws {
 public:
-    ofxGuiZoomableBaseDraws();
-    ofxGuiZoomableBaseDraws(string graphicsName, ofBaseDraws* graphics = 0, float w = 0, float h = 0);
-    ofxGuiZoomableBaseDraws(ofBaseDraws* tex, float w = defaultWidth, float h = 0);
+    ofxGuiZoomableBaseDraws(const ofxGuiBaseDraws::Config & config);
     virtual ~ofxGuiZoomableBaseDraws();
-
-    ofxGuiZoomableBaseDraws * setup(string graphicsName = "", ofBaseDraws* graphics = 0, float w = 0, float h = 0);
-
     virtual bool mouseMoved(ofMouseEventArgs & args){return false;}
     virtual bool mousePressed(ofMouseEventArgs & args);
     virtual bool mouseDragged(ofMouseEventArgs & args);

--- a/src/ofxLabelExtended.cpp
+++ b/src/ofxLabelExtended.cpp
@@ -10,8 +10,7 @@ void ofxLabelExtended::setShowLabelName(bool value){
 	showLabelName = value;
 }
 
-bool ofxLabelExtended::isLabelNameShown()
-{
+bool ofxLabelExtended::isLabelNameShown() const{
     return showLabelName;
 }
 

--- a/src/ofxLabelExtended.cpp
+++ b/src/ofxLabelExtended.cpp
@@ -1,28 +1,20 @@
 #include "ofxLabelExtended.h"
 using namespace std;
 
-ofxLabelExtended::ofxLabelExtended(ofParameter<string> _label, float width, float height, bool _showLabelName){
-	setup(_label,width,height,_showLabelName);
+ofxLabelExtended::ofxLabelExtended(ofParameter<string> label, const Config & c)
+:ofxLabel(label,c){
+    showLabelName = c.showName;
 }
 
-ofxLabelExtended* ofxLabelExtended::setup(ofParameter<string> _label, float width, float height, bool _showLabelName){
-    ofxLabel::setup(_label, width, height);
-    showLabelName = _showLabelName;
-    return this;
+void ofxLabelExtended::setShowLabelName(bool value){
+	showLabelName = value;
 }
 
-ofxLabelExtended* ofxLabelExtended::setup(string labelName, string _label, float width, float height, bool _showLabelName){
-    label.set(labelName,_label);
-    return setup(label,width,height,_showLabelName);
-}
-ofxLabelExtended * ofxLabelExtended::setShowLabelName(bool value){
-    showLabelName = value;
-    return this;
-}
 bool ofxLabelExtended::isLabelNameShown()
 {
     return showLabelName;
 }
+
 void ofxLabelExtended::generateDraw(){
 	bg.clear();
 

--- a/src/ofxLabelExtended.h
+++ b/src/ofxLabelExtended.h
@@ -3,15 +3,18 @@
 
 class ofxLabelExtended: public ofxLabel {
 public:
-    ofxLabelExtended(){}
-    ofxLabelExtended(ofParameter<std::string> _label, float width = defaultWidth, float height = defaultHeight, bool _showLabelName = true);
+	struct Config: public ofxLabel::Config{
+		Config(){}
+		Config(const ofxLabel::Config & c)
+		:ofxLabel::Config(c){}
+		Config(const ofxBaseGui::Config & c)
+		:ofxLabel::Config(c){}
+		bool showName = true;
+	};
+    ofxLabelExtended(ofParameter<std::string> _label, const Config & c);
 
-    ofxLabelExtended * setup(ofParameter<std::string> _label, float width = defaultWidth, float height = defaultHeight, bool _showLabelName = true);
-    ofxLabelExtended * setup(std::string labelName, std::string label, float width = defaultWidth, float height = defaultHeight, bool _showLabelName = true);
-
-    ofxLabelExtended * setShowLabelName(bool value = true);
-
-    bool isLabelNameShown();
+    void setShowLabelName(bool value = true);
+    bool isLabelNameShown() const;
 protected:
     void generateDraw();
     bool showLabelName;

--- a/src/ofxMinimalButton.cpp
+++ b/src/ofxMinimalButton.cpp
@@ -2,39 +2,19 @@
 #include "ofGraphics.h"
 using namespace std;
 
-ofxMinimalButton::ofxMinimalButton(){
+ofxMinimalButton::ofxMinimalButton(const Config & config)
+:ofxMinimalToggle(ofParameter<bool>(config.name,false),config){
 	value.setSerializable(false);
-}
-
-ofxMinimalButton::ofxMinimalButton(string toggleName, float width, float height):ofxMinimalToggle(){
-    if(width == 0) {
-         width = getTextWidth(toggleName, height);
+    if(b.width == 0) {
+    	b.width = getTextWidth(config.name, config.shape.height);
     }
-    setup(toggleName, width, height);
+	bGuiActive = false;
+    checkboxRect.set(1, 1, b.width - 2, b.height - 2);
+    value.addListener(this,&ofxMinimalButton::valueChanged);
 }
 
 ofxMinimalButton::~ofxMinimalButton(){
     value.removeListener(this,&ofxMinimalButton::valueChanged);
-}
-
-ofxMinimalButton* ofxMinimalButton::setup(string toggleName, float width, float height){
-    if(width == 0) {
-         width = getTextWidth(toggleName, height);
-    }
-	setName(toggleName);
-	b.x = 0;
-	b.y = 0;
-	b.width = width;
-	b.height = height;
-	bGuiActive = false;
-	value = false;
-    checkboxRect.set(1, 1, b.width - 2, b.height - 2);
-
-	registerMouseEvents();
-
-    value.addListener(this,&ofxMinimalButton::valueChanged);
-
-	return this;
 }
 
 bool ofxMinimalButton::mouseReleased(ofMouseEventArgs & args){
@@ -45,18 +25,6 @@ bool ofxMinimalButton::mouseReleased(ofMouseEventArgs & args){
 	}else{
 		return false;
 	}
-}
-
-bool ofxMinimalButton::mouseMoved(ofMouseEventArgs & args){
-    return ofxMinimalToggle::mouseMoved(args);
-}
-
-bool ofxMinimalButton::mousePressed(ofMouseEventArgs & args){
-    return ofxMinimalToggle::mousePressed(args);
-}
-
-bool ofxMinimalButton::mouseDragged(ofMouseEventArgs & args){
-    return ofxMinimalToggle::mouseDragged(args);
 }
 
 void ofxMinimalButton::valueChanged(bool & value){

--- a/src/ofxMinimalButton.h
+++ b/src/ofxMinimalButton.h
@@ -4,18 +4,19 @@
 #include "ofParameter.h"
 
 class ofxMinimalButton : public ofxMinimalToggle {
-	friend class ofPanel;
-	
 public:
-    ofxMinimalButton();
-    ofxMinimalButton(string toggleName, float width = defaultWidth, float height = defaultHeight);
+	struct Config: public ofxToggle::Config{
+		Config(){}
+		Config(const ofxToggle::Config & c)
+		:ofxToggle::Config(c){}
+		Config(const ofxBaseGui::Config & c)
+		:ofxToggle::Config(c){}
+		std::string name;
+	};
+    ofxMinimalButton(const Config & config);
     ~ofxMinimalButton();
-    ofxMinimalButton* setup(string toggleName, float width = defaultWidth, float height = defaultHeight);
 
 	virtual bool mouseReleased(ofMouseEventArgs & args);
-	virtual bool mouseMoved(ofMouseEventArgs & args);
-	virtual bool mousePressed(ofMouseEventArgs & args);
-	virtual bool mouseDragged(ofMouseEventArgs & args);
 
 	template<class ListenerClass, typename ListenerMethod>
 	void addListener(ListenerClass * listener, ListenerMethod method){

--- a/src/ofxMinimalToggle.cpp
+++ b/src/ofxMinimalToggle.cpp
@@ -2,58 +2,12 @@
 #include "ofGraphics.h"
 using namespace std;
 
-ofxMinimalToggle::ofxMinimalToggle(){
+ofxMinimalToggle::ofxMinimalToggle(ofParameter<bool> val, const Config & config)
+:ofxToggle(val,config){
     thisBorderColor = thisFillColor;
-}
-
-ofxMinimalToggle::ofxMinimalToggle(ofParameter<bool> _bVal, float width, float height):ofxToggle(){
-    setup(_bVal, width, height);
-    thisBorderColor = thisFillColor;
-}
-
-ofxMinimalToggle::~ofxMinimalToggle(){
-    value.removeListener(this,&ofxMinimalToggle::valueChanged);
-}
-
-ofxMinimalToggle * ofxMinimalToggle::setup(ofParameter<bool> _bVal, float width, float height){
-    if(width == 0) {
-        width = getTextWidth(_bVal.getName(), height);
+    if(b.width == 0) {
+    	b. width = getTextWidth(val.getName(), config.shape.height);
     }
-    b.x = 0;
-    b.y = 0;
-    b.width = width;
-    b.height = height;
-    bGuiActive = false;
-    value.makeReferenceTo(_bVal);
-
-    value.addListener(this,&ofxMinimalToggle::valueChanged);
-    registerMouseEvents();
-    setNeedsRedraw();
-
-    return this;
-
-}
-
-ofxMinimalToggle * ofxMinimalToggle::setup(string toggleName, bool _bVal, float width, float height){
-    value.set(toggleName,_bVal);
-    return setup(value,width,height);
-}
-
-
-bool ofxMinimalToggle::mouseMoved(ofMouseEventArgs & args){
-    return ofxToggle::mouseMoved(args);
-}
-
-bool ofxMinimalToggle::mousePressed(ofMouseEventArgs & args){
-    return ofxToggle::mousePressed(args);
-}
-
-bool ofxMinimalToggle::mouseDragged(ofMouseEventArgs & args){
-    return ofxToggle::mouseDragged(args);
-}
-
-bool ofxMinimalToggle::mouseReleased(ofMouseEventArgs & args){
-    return ofxToggle::mouseReleased(args);
 }
 
 
@@ -117,8 +71,4 @@ float ofxMinimalToggle::getTextWidth(string text, float _height) {
     }
     _width += textPadding*2;
     return _width;
-}
-
-void ofxMinimalToggle::valueChanged(bool & value){
-    ofxToggle::valueChanged(value);
 }

--- a/src/ofxMinimalToggle.h
+++ b/src/ofxMinimalToggle.h
@@ -4,43 +4,16 @@
 #include "ofxToggle.h"
 
 class ofxMinimalToggle : public ofxToggle {
-
-    friend class ofxToggleMatrix;
-
 public:
-    ofxMinimalToggle();
-    ~ofxMinimalToggle();
-    ofxMinimalToggle(ofParameter<bool> _bVal, float width = defaultWidth, float height = defaultHeight);
-
-    ofxMinimalToggle * setup(ofParameter<bool> _bVal, float width = defaultWidth, float height = defaultHeight);
-    ofxMinimalToggle * setup(std::string toggleName, bool _bVal, float width = defaultWidth, float height = defaultHeight);
-
-    void resize(float w, float h);
-
-    virtual bool mouseReleased(ofMouseEventArgs & args);
-    virtual bool mouseMoved(ofMouseEventArgs & args);
-    virtual bool mousePressed(ofMouseEventArgs & args);
-    virtual bool mouseDragged(ofMouseEventArgs & args);
-
-    template<class ListenerClass, typename ListenerMethod>
-    void addListener(ListenerClass * listener, ListenerMethod method){
-        ofAddListener(triggerEvent,listener,method);
-    }
-
-    template<class ListenerClass, typename ListenerMethod>
-    void removeListener(ListenerClass * listener, ListenerMethod method){
-        ofRemoveListener(triggerEvent,listener,method);
-    }
+    ofxMinimalToggle(ofParameter<bool> _bVal, const ofxToggle::Config & config);
+    virtual ~ofxMinimalToggle(){}
 
 protected:
     virtual void render();
     void generateDraw();
 
-    ofEvent<void> triggerEvent;
-    void valueChanged(bool & v);
-
     bool setValue(float mx, float my, bool bCheck);
-    float getTextWidth(string text, float height);
+    float getTextWidth(std::string text, float height);
 
     ofPath border;
 };

--- a/src/ofxPanelExtended.cpp
+++ b/src/ofxPanelExtended.cpp
@@ -23,20 +23,20 @@ ofxPanelExtended::~ofxPanelExtended(){
     unregisterMouseEvents();
 }
 
-ofxPanelExtended * ofxPanelExtended::setup(string collectionName, string filename, float x, float y){
+ofxPanelExtended & ofxPanelExtended::setup(string collectionName, string filename, float x, float y){
     if(!loadIcon.isAllocated() || !saveIcon.isAllocated()){
         loadIcons();
     }
     registerMouseEvents();
-    return (ofxPanelExtended*)ofxGuiGroup::setup(collectionName,filename,x,y);
+    return (ofxPanelExtended&)ofxGuiGroup::setup(collectionName,filename,x,y);
 }
 
-ofxPanelExtended * ofxPanelExtended::setup(const ofParameterGroup & parameters, string filename, float x, float y){
+ofxPanelExtended & ofxPanelExtended::setup(const ofParameterGroup & parameters, string filename, float x, float y){
     if(!loadIcon.isAllocated() || !saveIcon.isAllocated()){
         loadIcons();
     }
     registerMouseEvents();
-    return (ofxPanelExtended*)ofxGuiGroup::setup(parameters,filename,x,y);
+    return (ofxPanelExtended&)ofxGuiGroup::setup(parameters,filename,x,y);
 }
 
 void ofxPanelExtended::loadIcons(){

--- a/src/ofxPanelExtended.h
+++ b/src/ofxPanelExtended.h
@@ -14,8 +14,8 @@ public:
     ofxPanelExtended(const ofParameterGroup & parameters, std::string filename="settings.xml", float x = 10, float y = 10);
     ~ofxPanelExtended();
 
-    ofxPanelExtended * setup(std::string collectionName="", std::string filename="settings.xml", float x = 10, float y = 10);
-    ofxPanelExtended * setup(const ofParameterGroup & parameters, std::string filename="settings.xml", float x = 10, float y = 10);
+    ofxPanelExtended & setup(std::string collectionName="", std::string filename="settings.xml", float x = 10, float y = 10);
+    ofxPanelExtended & setup(const ofParameterGroup & parameters, std::string filename="settings.xml", float x = 10, float y = 10);
 
     bool mouseReleased(ofMouseEventArgs & args);
 

--- a/src/ofxRotarySlider.cpp
+++ b/src/ofxRotarySlider.cpp
@@ -4,16 +4,14 @@
 using namespace std;
 
 template<typename Type>
-ofxRotarySlider<Type>::ofxRotarySlider(){
+ofxRotarySlider<Type>::ofxRotarySlider(ofParameter<Type> _val, const Config & config)
+:ofxSlider<Type>(_val,config)
+ ,_mouseOffset(0){
+
 }
 
 template<typename Type>
 ofxRotarySlider<Type>::~ofxRotarySlider(){
-}
-
-template<typename Type>
-ofxRotarySlider<Type>::ofxRotarySlider(ofParameter<Type> _val, float width, float height){
-    ofxSlider<Type>::setup(_val,width,height);
 }
 
 template<typename Type>

--- a/src/ofxRotarySlider.h
+++ b/src/ofxRotarySlider.h
@@ -5,13 +5,17 @@
 
 template<typename Type>
 class ofxRotarySlider : public ofxSlider<Type>{
-    friend class ofPanel;
-
 public:
-    ofxRotarySlider();
-    ~ofxRotarySlider();
-    ofxRotarySlider(ofParameter<Type> _val, float width = ofxBaseGui::defaultWidth, float height = ofxBaseGui::defaultHeight);
+	struct Config: public ofxSlider<Type>::Config{
+		Config(){}
+		Config(const typename ofxSlider<Type>::Config & config)
+		:ofxSlider<Type>::Config(config){}
+		Config(const ofxBaseGui::Config & config)
+		:ofxSlider<Type>::Config(config){}
 
+	};
+	ofxRotarySlider(ofParameter<Type> _val, const Config & config);
+    virtual ~ofxRotarySlider();
     virtual bool mousePressed(ofMouseEventArgs & args);
 
 protected:

--- a/src/ofxTabbedPages.cpp
+++ b/src/ofxTabbedPages.cpp
@@ -10,12 +10,12 @@ ofxTabbedPages::~ofxTabbedPages(){
     //
 }
 
-ofxTabbedPages * ofxTabbedPages::setup(string collectionName, string filename, float x, float y) {
+ofxTabbedPages & ofxTabbedPages::setup(string collectionName, string filename, float x, float y) {
     ofxGuiPage::setup(collectionName,filename,x,y);
     tabs.setup();
     tabs.setShowHeader(false);
     tabs.allowMultipleActiveToggles(false);
-    tabs.setAlignHorizontal();
+    tabs.setLayout(ofxBaseGui::Horizontal);
     tabs.setBorderColor(ofColor(0,0,0,0));
     tabs.setDefaultBackgroundColor(thisBorderColor);
     tabs.setDefaultBorderColor(thisBorderColor);
@@ -26,14 +26,14 @@ ofxTabbedPages * ofxTabbedPages::setup(string collectionName, string filename, f
     sizeChangedCB();
     collection.push_back(&tabs);
     parameters.add(tabs.getParameter());
-    return this;
+    return *this;
 }
 
 void ofxTabbedPages::add(ofxGuiPage *element) {
     collection.push_back(element);
 
     parameters_tabs.push_back(ofParameter<bool>(element->getName(),false));
-    tabs.add(new ofxMinimalToggle(parameters_tabs.at(parameters_tabs.size()-1),tabWidth,tabHeight));
+    tabs.add<ofxMinimalToggle>(parameters_tabs.at(parameters_tabs.size()-1));
     if(element->getBackgroundColor()!=thisBackgroundColor) {
         tabs.getControl(tabs.getNumControls()-1)->setBackgroundColor(element->getBackgroundColor());
         tabs.getControl(tabs.getNumControls()-1)->setBorderColor(element->getBackgroundColor());
@@ -247,7 +247,7 @@ void ofxTabbedPages::sizeChangedCB(){
     for(unsigned int i = 1; i < collection.size(); i++) {
         collection[i]->setShape(pagesShape);
     }
-    if(parent) parent->sizeChangedCB();
+    ofNotifyEvent(sizeChangedE,this);
     setNeedsRedraw();
 }
 

--- a/src/ofxTabbedPages.h
+++ b/src/ofxTabbedPages.h
@@ -8,9 +8,8 @@ public:
     ofxTabbedPages();
     ~ofxTabbedPages();
 
-    ofxTabbedPages * setup(std::string collectionName="", std::string filename="settings.xml", float x = 10, float y = 10);
-
-    void add(ofxGuiPage * element);
+    ofxTabbedPages & setup(std::string collectionName="", std::string filename="settings.xml", float x = 10, float y = 10);
+    using ofxGuiGroup::add;
 
     void clear();
 
@@ -31,11 +30,11 @@ protected:
     void updateContentShapes();
     void setSizeToElement(ofxBaseGui *element);
     virtual void sizeChangedCB();
-
+    void add(ofxGuiPage * element);
 private:
 
     ofxGuiGroupExtended tabs;
-    vector<ofParameter<bool>> parameters_tabs;
+    std::vector<ofParameter<bool>> parameters_tabs;
     float tabHeight, tabWidth;
     ofRectangle pagesShape, tabShape;
     ofPath bg;

--- a/src/ofxValuePlotter.cpp
+++ b/src/ofxValuePlotter.cpp
@@ -2,30 +2,23 @@
 #include "ofGraphics.h"
 using namespace std;
 
-ofxValuePlotter::ofxValuePlotter() {}
-
-ofxValuePlotter::ofxValuePlotter(string label, float minValue, float maxValue, int plotSize, float width, float height){
-    setup(label, minValue, maxValue, plotSize, width, height);
+ofxValuePlotter::ofxValuePlotter(ofParameter<float> value, const Config & config)
+:ofxBaseGui(config)
+,plotSize(config.plotSize)
+,minVal(config.minValue)
+,maxVal(config.maxValue)
+,decimalPlace(config.decimalPlace){
+    autoscale = minVal == maxVal;
+    buffer.clear();
+	this->value.makeReferenceTo(value);
+    this->value.addListener(this, &ofxValuePlotter::update);
+    setNeedsRedraw();
 }
 
 ofxValuePlotter::~ofxValuePlotter(){
 }
 
-ofxValuePlotter* ofxValuePlotter::setup(string label, float minValue, float maxValue, int plotSize, float width, float height) {
-    b.width  = width;
-    b.height = height;
-    minVal = minValue;
-    maxVal = maxValue;
-    autoscale = minVal == maxVal;
-    buffer.clear();
-    this->plotSize = plotSize;
-    setName(label);
-    setNeedsRedraw();
-    return this;
-}
-
-void ofxValuePlotter::update(float value) {
-    lastVal = value;
+void ofxValuePlotter::update(float & value) {
     if(plotSize > 0) {
         buffer.push_back(value);
 
@@ -53,8 +46,7 @@ void ofxValuePlotter::generateDraw(){
     bg.setFilled(true);
     bg.rectangle(b);
 
-    string name = ofToString(lastVal,decimalPlace) +  " " + this->getName();
-    label = name;
+    string name = ofToString(value,decimalPlace) +  " " + this->getName();
 
     textMesh = getTextMesh(name, b.x+textPadding, b.y + b.height / 2 + 4);
 
@@ -101,5 +93,5 @@ void ofxValuePlotter::render() {
 }
 
 ofAbstractParameter & ofxValuePlotter::getParameter(){
-    return label;
+    return value;
 }

--- a/src/ofxValuePlotter.h
+++ b/src/ofxValuePlotter.h
@@ -4,13 +4,19 @@
 
 class ofxValuePlotter: public ofxBaseGui {
 public:
-    ofxValuePlotter();
-    ofxValuePlotter(string label, float minValue=0, float maxValue=0, int plotSize=100, float width = defaultWidth, float height = defaultHeight);
+	struct Config: ofxBaseGui::Config{
+		Config(){}
+		Config(const ofxBaseGui::Config & c)
+		:ofxBaseGui::Config(c){}
+
+		float minValue=0;
+		float maxValue=0;
+		int plotSize=100;
+	    int decimalPlace=3;
+	};
+    ofxValuePlotter(ofParameter<float> value, const Config & config);
     virtual ~ofxValuePlotter();
 
-    ofxValuePlotter * setup(string label="", float minValue=0, float maxValue=0, int plotSize=100, float width = defaultWidth, float height = defaultHeight);
-
-    void update(float value);
     void setDecimalPlace(int place);
 
     // Abstract methods we must implement, but have no need for!
@@ -27,15 +33,15 @@ protected:
     bool setValue(float mx, float my, bool bCheckBounds){return false;}
     void render();
     void generateDraw();
+    void update(float & value);
     ofPath bg;
     ofVboMesh textMesh;
-    vector<float> buffer;
+    std::vector<float> buffer;
     int plotSize;
     ofPath plot;
-    float lastVal;
     float minVal, maxVal;
     bool autoscale;
-    int decimalPlace=3;
-    ofParameter<string> label;
+    int decimalPlace;
+    ofParameter<float> value;
 
 };

--- a/src/ofxVerticalSlider.cpp
+++ b/src/ofxVerticalSlider.cpp
@@ -3,16 +3,13 @@
 using namespace std;
 
 template<typename Type>
-ofxVerticalSlider<Type>::ofxVerticalSlider(){
+ofxVerticalSlider<Type>::ofxVerticalSlider(ofParameter<Type> val, const Config & config)
+:ofxSlider<Type>(val,config){
+
 }
 
 template<typename Type>
 ofxVerticalSlider<Type>::~ofxVerticalSlider(){
-}
-
-template<typename Type>
-ofxVerticalSlider<Type>::ofxVerticalSlider(ofParameter<Type> _val, float width, float height){
-    ofxSlider<Type>::setup(_val,width,height);
 }
 
 template<typename Type>

--- a/src/ofxVerticalSlider.h
+++ b/src/ofxVerticalSlider.h
@@ -4,12 +4,17 @@
 
 template<typename Type>
 class ofxVerticalSlider : public ofxSlider<Type>{
-	friend class ofPanel;
-	
 public:	
-    ofxVerticalSlider();
-    ~ofxVerticalSlider();
-    ofxVerticalSlider(ofParameter<Type> _val, float width = ofxBaseGui::defaultHeight, float height = ofxBaseGui::defaultWidth);
+	struct Config: public ofxSlider<Type>::Config{
+		Config(){}
+		Config(const typename ofxSlider<Type>::Config & config)
+		:ofxSlider<Type>::Config(config){}
+		Config(const ofxBaseGui::Config & config)
+		:ofxSlider<Type>::Config(config){}
+
+	};
+    ofxVerticalSlider(ofParameter<Type> _val, const Config & config);
+    virtual ~ofxVerticalSlider();
 
 	template<class ListenerClass, typename ListenerMethod>
 	void addListener(ListenerClass * listener, ListenerMethod method){


### PR DESCRIPTION
This adapts ofxGuiExtended to the changes in https://github.com/openframeworks/openFrameworks/pull/4150

I've added to ofxBaseGui 2 new properties, a layout (which right now can be vertical and horizontal) and a boolean inContainer. that solves all the cases where parent was being used.

then i've refactored you controls a bit, mostly to get rid of the places where it used parent, and added a config struct to some of the controls. i've also changed the setup methods to return a reference instead of a pointer and even removed some setup methods in favor of the new templated add methods in ofxGuiGroup.

the exampleControls is also refactored to the new syntax.

this is not complete but just as a first step towards integrating it with ofxGui. don't merge it into your master cause that will break the addon with current OF but just to see what you think about the changes.

i think we could:
- integrate ofxPanelExtended and ofxGuiGroupExtended's functionality in ofxPanel and ofxGuiGroup
- adding an ofxGuiSpacer is a little verbose with the new syntax so it would be good to also integrate it into ofxGuiGroup so we can do: `panel.addSpacer(40)` for example.
- i'm not very sure about the utility of a rotary slider, the canvas and the master slave control but the rest of them seem really useful so i think we could merge then with ofxGui right away or at least with my branch and then into master once 0.9 is out
