### PR TITLE
implements `isMousePressed()`

### DIFF
--- a/src/ofxGuiElement.cpp
+++ b/src/ofxGuiElement.cpp
@@ -710,6 +710,10 @@ bool ofxGuiElement::isMouseOver() const{
 	return _isMouseOver;
 }
 
+bool ofxGuiElement::isMousePressed() const{
+	return _isMousePressed;
+}
+
 void ofxGuiElement::setDraggable(bool draggable){
 	_isDraggable = draggable;
 }
@@ -746,7 +750,7 @@ bool ofxGuiElement::mouseDragged(ofMouseEventArgs & args){
 bool ofxGuiElement::mousePressed(ofMouseEventArgs & args){
 	if(!isHidden()){
 		if(localToScreen(ofRectangle(0,0,getWidth(),getHeight())).inside(args.x, args.y)){
-			_isMouseOver = true;
+			_isMouseOver = _isMousePressed = true;
 			if(_isDraggable){
 				_isDragging = true;
 				grabPoint = ofPoint(args.x, args.y) - getScreenPosition();
@@ -755,10 +759,12 @@ bool ofxGuiElement::mousePressed(ofMouseEventArgs & args){
 		}else {
 			_isDragging = false;
 			_isMouseOver = false;
+			_isMousePressed = false;
 		}
 	}else {
 		_isDragging = false;
 		_isMouseOver= false;
+		_isMousePressed = false;
 	}
 	return false;
 }
@@ -785,6 +791,7 @@ bool ofxGuiElement::mouseReleased(ofMouseEventArgs & args){
 			_isMouseOver = false;
 		}
 	}
+	_isMousePressed = false;
 	_isDragging = false;
 	return false;
 }

--- a/src/ofxGuiElement.h
+++ b/src/ofxGuiElement.h
@@ -157,6 +157,9 @@ class ofxGuiElement : public DOM::Element {
 		/// \brief True if the pointer is over the widget.
 		bool _isMouseOver = false;
 
+		/// \brief True if the pointer is pressed over the widget.
+		bool _isMousePressed = false;
+
 		/// \brief Point where element is grabbed for dragging in screen coordinates
 		ofPoint grabPoint;
 


### PR DESCRIPTION
While being exposed, it was doing nothing so I basically PR that events' logic: when mouse is pressed and over -> `true`, when released wherever the cursor is -> `false`. This method can actually be useful to tweak UX responses when syncing value of an `ofParameter` based element with different sources (mouse, shortcuts, data).