### PR TITLE
Refactor theme update mechanism to resolve time type incompatibility

### DIFF
--- a/src/ofxGuiElement.cpp
+++ b/src/ofxGuiElement.cpp
@@ -1,4 +1,8 @@
 #include "ofxGuiElement.h"
+
+#include <chrono>
+#include <ctime>
+
 #include "containers/ofxGuiContainer.h"
 #include "ofImage.h"
 #include "ofBitmapFont.h"
@@ -167,7 +171,13 @@ void ofxGuiElement::loadTheme(const string &filename, bool updateOnFileChange){
 		if(!updateOnThemeChange){
 			updateOnThemeChange = true;
 			themeFilename = filename;
-			themeUpdated = std::filesystem::last_write_time(ofToDataPath(themeFilename));
+			auto ftime =
+				std::filesystem::last_write_time(ofToDataPath(themeFilename));
+			auto sctp = std::chrono::time_point_cast<
+				std::chrono::system_clock::duration>(
+				ftime - decltype(ftime)::clock::now() +
+				std::chrono::system_clock::now());
+			themeUpdated = std::chrono::system_clock::to_time_t(sctp);
 			ofAddListener(ofEvents().update, this, &ofxGuiElement::watchTheme);
 		}
 	}else{
@@ -184,7 +194,12 @@ void ofxGuiElement::loadTheme(const string &filename, bool updateOnFileChange){
 }
 
 void ofxGuiElement::watchTheme(ofEventArgs &args){
-	std::time_t newthemeUpdated = std::filesystem::last_write_time(ofToDataPath(themeFilename));
+	auto ftime = std::filesystem::last_write_time(ofToDataPath(themeFilename));
+	auto sctp =
+		std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+			ftime - decltype(ftime)::clock::now() +
+			std::chrono::system_clock::now());
+	std::time_t newthemeUpdated = std::chrono::system_clock::to_time_t(sctp);
 	if(newthemeUpdated != themeUpdated){
 		themeUpdated = newthemeUpdated;
 		loadTheme(themeFilename, true);


### PR DESCRIPTION
# Refactor Theme Update Mechanism for Compatibility with `std::filesystem::last_write_time`

## Overview

This pull request addresses issues with time type compatibility in the `ofxGuiElement` class by refactoring the theme update mechanism. Specifically, it resolves errors caused by attempting to assign `std::filesystem::last_write_time` (of type `file_time_type`) to `std::time_t`, which is not directly compatible.

## Key Changes

- **Time Conversion Update**: Replaced direct assignments from `std::filesystem::last_write_time` with an explicit conversion to `std::time_t`. This is achieved by:
  - Using `chrono::time_point_cast` to convert `file_time_type` to `system_clock::time_point`.
  - Converting the result to `std::time_t` using `system_clock::to_time_t`.
- **Header Adjustments**: Added `chrono` and `ctime` headers to support the new time conversion process.

## Rationale

These changes fix compilation errors on systems where `file_time_type` is incompatible with `std::time_t`, enabling successful builds.

## Testing

- Verified that the refactored code compiles and runs successfully on environments where `file_time_type` issues were previously encountered.

## Impact
This refactoring should have no impact on the behavior of `ofxGuiElement` other than fixing the noted compatibility issues.
